### PR TITLE
Feature/tools cleanup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,33 @@
-FROM alpine:3.3
+FROM alpine:edge
 
 # the following ENV need to be present
 ENV IAM_ROLE=none
 ENV MOUNT_POINT=/var/s3
 VOLUME /var/s3
 
-ARG S3FS_VERSION=v1.79
-
-RUN apk --update add fuse alpine-sdk automake autoconf libxml2-dev fuse-dev curl-dev git bash;
-RUN git clone https://github.com/s3fs-fuse/s3fs-fuse.git; \
- cd s3fs-fuse; \
- git checkout tags/${S3FS_VERSION}; \
- ./autogen.sh; \
- ./configure --prefix=/usr; \
- make; \
- make install; \
- rm -rf /var/cache/apk/*;
+ARG S3FS_VERSION=v1.80
+# Build-time metadata as defined at http://label-schema.org
+ARG BUILD_DATE
+ARG VCS_REF
+ARG VCS_URL
+ARG VERSION
+LABEL org.label-schema.build-date=$BUILD_DATE \
+  org.label-schema.name="Alpine/s3fs - Alpine Linux image w/Amazon S3 Support through Fuse-s3fs" \
+#  org.label-schema.description="Let it be pulled from Readme.md..." \
+  org.label-schema.url="https://github.com/rjocoleman/docker-alpine-s3fs/wiki" \
+  org.label-schema.vcs-ref=$VCS_REF \
+  org.label-schema.vcs-url=$VCS_URL \
+  org.label-schema.vendor="Robert Coleman <github@robert.net.nz>" \
+  org.label-schema.version=$VERSION \
+  org.label-schema.schema-version="1.0"
+RUN apk update && apk upgrade \
+  && apk add  --no-cache ca-certificates fuse libcurl libxml2 bash \
+  && apk add --no-cache --virtual .build-dependencies \
+	alpine-sdk automake autoconf libxml2-dev fuse-dev curl-dev git \
+  && git clone https://github.com/s3fs-fuse/s3fs-fuse.git \
+  && cd s3fs-fuse && git checkout tags/${S3FS_VERSION} \
+  && ./autogen.sh && ./configure --prefix=/usr && make && make install && cd .. \
+  && apk del .build-dependencies && rm -rf /var/cache/* s3fs-fuse
 
 COPY docker-entrypoint.sh /
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/Makefile
+++ b/Makefile
@@ -11,9 +11,18 @@ release:
 shell:
 	@docker run -t -i rjocoleman/alpine-s3fs:latest /bin/bash
 
+build-3.3:
+	# create a Dockerfile version with a different source image, delete it afterwards
+	@sed -e 's/alpine:edge/alpine:3.3/' Dockerfile > Dockerfile-3.3
+	@docker build -t rjocoleman/alpine-s3fs:3.3 -f Dockerfile-3.3 .
+	@rm Dockerfile-3.3
+
+release-3.3:
+        @docker push rjocoleman/alpine-s3fs:3.3
+
 build-ruby:
 	# create a Dockerfile version with a different source image, delete it afterwards
-	@sed -e 's/alpine:3.3/ruby:2-alpine/' Dockerfile > Dockerfile-ruby2
+	@sed -e 's/alpine:edge/ruby:2-alpine/' Dockerfile > Dockerfile-ruby2
 	@docker build -t rjocoleman/alpine-s3fs:ruby2 -f Dockerfile-ruby2 .
 	@rm Dockerfile-ruby2
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # alpine-s3fs
+[![Docker Automated buil](https://img.shields.io/docker/automated/rjocoleman/alpine-s3fs.svg)](https://hub.docker.com/r/rjocoleman/alpine-s3fs/) [![](https://images.microbadger.com/badges/image/rjocoleman/alpine-s3fs.svg)](https://microbadger.com/images/rjocoleman/alpine-s3fs "Get your own image badge on microbadger.com") [![Docker Pulls](https://img.shields.io/docker/pulls/rjocoleman/alpine-s3fs.svg)](https://hub.docker.com/r/rjocoleman/alpine-s3fs/) [![Docker Stars](https://img.shields.io/docker/stars/rjocoleman/alpine-s3fs.svg)](https://hub.docker.com/r/rjocoleman/alpine-s3fs/) [![](https://images.microbadger.com/badges/commit/rjocoleman/alpine-s3fs.svg)](https://microbadger.com/images/rjocoleman/alpine-s3fs "Get your own commit badge on microbadger.com")
 
 Use [s3fs](https://github.com/s3fs-fuse/s3fs-fuse) with Alpine Linux to mount an S3 bucket as a directory in the filesystem.  
 Uses environment variables to configure.
@@ -25,6 +26,7 @@ IAM_ROLE= # optional IAM role name, for usage on EC2.
 ## Usage
 
 As a base image for a container. ENV `MOUNT_POINT` can be changed to direct the mount point to a different directory as required.
+It should be noted that recent versions of Docker have clamped down on privileges within docker images so you'll likely need to run the image with the `--privileged` argument in order to allow s3fs access to the /dev/flash device within the image.
 
 ### Note
 

--- a/hooks/build
+++ b/hooks/build
@@ -1,0 +1,7 @@
+#!/bin/bash
+FOO=${IMAGE_NAME:=`whoami`/docker-alpine-s3fs:local}
+BAR=${SOURCE_BRANCH:=`git rev-parse --abbrev-ref HEAD`}
+docker build --build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
+             --build-arg VCS_REF=`git rev-parse --short HEAD` \
+             --build-arg VCS_URL=`git config --get remote.origin.url` \
+             --build-arg VERSION=$SOURCE_BRANCH -t $IMAGE_NAME .


### PR DESCRIPTION
This patch updates the docker file to remove the build tools after the build is complete, reducing the image size by over 90% also adding automated build hooks with label metadata additions. Also updated to Alpine 3.4 and Fuse-s3fs 1.80. The build hooks are intended to interoperate with the Docker Hub Automated build system. See https://hub.docker.com/r/hillct/docker-alpine-s3fs/tags/